### PR TITLE
Fix 'GATT operation not permitted' by picking the writable characteristic

### DIFF
--- a/js/bluetooth.js
+++ b/js/bluetooth.js
@@ -1,25 +1,86 @@
+// Characteristics resolved after connecting, picked by their properties.
+let writeCharacteristic = null;
+let notifyCharacteristic = null;
+
+// Writes are serialized: the browser rejects a GATT operation started while
+// another one is still running (the joystick can fire faster than that).
+let writeQueue = Promise.resolve();
+
+const CHARACTERISTIC_PROPERTIES = ['broadcast', 'read', 'writeWithoutResponse', 'write', 'notify', 'indicate', 'authenticatedSignedWrites', 'reliableWrite', 'writableAuxiliaries'];
+
+
 function connectToBle() {
   // Connect to a device by passing the service UUID
   blueTooth.connect(0xFFE0, gotCharacteristics);
 }
 
 
+function listProperties(characteristic) {
+  const properties = characteristic.properties || {};
+  return CHARACTERISTIC_PROPERTIES.filter(function (name) { return properties[name]; });
+}
+
+
+function canWrite(characteristic) {
+  const properties = characteristic.properties || {};
+  return !!(properties.write || properties.writeWithoutResponse || properties.authenticatedSignedWrites);
+}
+
+
+function canNotify(characteristic) {
+  const properties = characteristic.properties || {};
+  return !!(properties.notify || properties.indicate);
+}
+
+
 // A function that will be called once got characteristics
 function gotCharacteristics(error, characteristics) {
-  if (error) { 
+  if (error) {
     console.log('error: ', error);
   }
   console.log('characteristics: ', characteristics);
-  blueToothCharacteristic = characteristics[0];
+  if (!characteristics || !characteristics.length) {
+    Swal.fire({
+      icon: 'error',
+      title: 'No characteristic found',
+      text: 'The device was paired but the service FFE0 is empty, so no command can be sent.'
+    });
+    return;
+  }
+  characteristics.forEach(function (characteristic) {
+    console.log('  ' + characteristic.uuid + ' -> ' + listProperties(characteristic).join(', '));
+  });
 
-  blueTooth.startNotifications(blueToothCharacteristic, gotValue, 'string');
-  
+  // Bluetooth modules do not agree on the order of the characteristics inside
+  // the FFE0 service, and some of them split the serial port in two: one
+  // characteristic to notify and another one to write. Picking
+  // characteristics[0] blindly ends up writing to a read/notify only
+  // characteristic, which the browser rejects with
+  // "NotSupportedError: GATT operation not permitted."
+  writeCharacteristic = characteristics.find(canWrite) || null;
+  notifyCharacteristic = characteristics.find(canNotify) || null;
+  blueToothCharacteristic = writeCharacteristic || characteristics[0];
+
+  if (notifyCharacteristic) {
+    blueTooth.startNotifications(notifyCharacteristic, gotValue, 'string');
+  } else {
+    console.warn('No characteristic supports notifications, sensor values will not be received.');
+  }
+
   isConnected = blueTooth.isConnected();
   if(isConnected) {
     document.getElementsByClassName('container__bluetooth--icon')[0].style.display = "block";
     document.getElementsByClassName('container__bluetooth--icon')[0].style.backgroundColor = "#32D900";
     SetRobot();
-    Swal.fire('Connected!', '', 'success');
+    if (writeCharacteristic) {
+      Swal.fire('Connected!', '', 'success');
+    } else {
+      Swal.fire({
+        icon: 'error',
+        title: 'Connected, but this module cannot receive commands',
+        html: 'None of the characteristics of the service FFE0 accepts writes, so the robot will ignore every command.<br>Check that your bluetooth module is a BLE 4.0 serial module (HM-10 and compatibles).'
+      });
+    }
   }
   // Add a event handler when the device is disconnected
   blueTooth.onDisconnected(onDisconnected);
@@ -39,6 +100,41 @@ function onDisconnected() {
   console.log('Device got disconnected.');
   isConnected = false;
   OttoConnected = false;
+  writeCharacteristic = null;
+  notifyCharacteristic = null;
+  blueToothCharacteristic = null;
+}
+
+
+// Try the write flavours the characteristic advertises, newest API first.
+// writeValue() is deprecated and picks the flavour on its own, so it stays as
+// the last resort for older browsers.
+function writeChunk(chunk) {
+  const properties = writeCharacteristic.properties || {};
+  const attempts = [];
+  if (properties.writeWithoutResponse && writeCharacteristic.writeValueWithoutResponse) {
+    attempts.push(function () { return writeCharacteristic.writeValueWithoutResponse(chunk); });
+  }
+  if (properties.write && writeCharacteristic.writeValueWithResponse) {
+    attempts.push(function () { return writeCharacteristic.writeValueWithResponse(chunk); });
+  }
+  attempts.push(function () { return writeCharacteristic.writeValue(chunk); });
+
+  return attempts.reduce(function (chain, attempt) {
+    return chain.catch(attempt);
+  }, Promise.reject());
+}
+
+
+function writeBytes(bytes) {
+  // BLE 4.0 serial modules only forward 20 bytes per write (23 bytes MTU
+  // minus the 3 bytes ATT header), longer commands get truncated.
+  let chain = Promise.resolve();
+  for (let offset = 0; offset < bytes.length; offset += 20) {
+    const chunk = bytes.slice(offset, offset + 20);
+    chain = chain.then(function () { return writeChunk(chunk); });
+  }
+  return chain;
 }
 
 
@@ -46,7 +142,19 @@ function sendData(command) {
   const inputValue = command;
   if (!("TextEncoder" in window)) {
     console.log("Sorry, this browser does not support TextEncoder...");
+    return;
+  }
+  if (!writeCharacteristic) {
+    console.error('There is no writable characteristic, "' + inputValue.trim() + '" was not sent.');
+    return;
   }
   var enc = new TextEncoder(); // always utf-8
-  blueToothCharacteristic.writeValue(enc.encode(inputValue));
+  const bytes = enc.encode(inputValue);
+
+  writeQueue = writeQueue.then(function () {
+    return writeBytes(bytes);
+  }).catch(function (error) {
+    console.error('Could not send "' + inputValue.trim() + '": ', error);
+  });
+  return writeQueue;
 }


### PR DESCRIPTION
## Problem

Sending any command to the robot fails with the following error in the browser console, even though the device pairs and connects successfully:

```
Uncaught (in promise) NotSupportedError: GATT operation not permitted.
```

Chrome throws `NotSupportedError: GATT operation not permitted.` when `writeValue()` is called on a characteristic whose properties include neither `write` nor `writeWithoutResponse`.

`gotCharacteristics()` in `js/bluetooth.js` picked the target characteristic by position:

```js
blueToothCharacteristic = characteristics[0];
```

`getCharacteristics()` does not guarantee any order, and several BLE 4.0 serial modules (HM-10 clones such as CC41-A, AT-09 or MLT-BT05) expose more than one characteristic inside the FFE0 service, sometimes splitting the serial port into a notify-only characteristic and a separate writable one. When the first characteristic in the list happens to be the read/notify-only one, the connection and the sensor notifications work, but every command sent by `sendData()` is rejected.

## Changes

All changes are in `js/bluetooth.js`, which is shared by `index.html`, `ninja.html` and `calibration.html`, so all three pages are covered.

- **Pick the characteristics by their properties instead of by position.** The one advertising `write` / `writeWithoutResponse` is used to send commands, the one advertising `notify` / `indicate` is used to receive sensor values. `blueToothCharacteristic` is kept and now points at the writable characteristic, so nothing else in the codebase had to change.
- **Report the problem instead of failing silently.** Every characteristic of the service is logged on connect with its UUID and its properties, which makes unknown modules easy to diagnose. If no characteristic accepts writes, the user gets a clear message rather than an unhandled promise rejection on the first button press.
- **Fall back through the available write methods:** `writeValueWithoutResponse()`, then `writeValueWithResponse()`, then the deprecated `writeValue()` for older browsers.
- **Serialize the writes.** The joystick can emit commands faster than a GATT operation completes, which made the browser reject the overlapping ones. Writes now go through a promise queue.
- **Split the payload into 20-byte chunks.** BLE 4.0 modules only forward 20 bytes per write (23-byte MTU minus the 3-byte ATT header), so longer commands such as the calibration and settings strings were being truncated.
- Clear the cached characteristics on disconnect.

## Notes

- No change to the wire protocol, the command strings or the Arduino side.
- No change to the public functions: `connectToBle()`, `sendData()`, `gotValue()` and `onDisconnected()` keep the same names and signatures.
- Modules whose first characteristic was already the writable one (genuine HM-10) keep working exactly as before.

## Testing

<!-- Please describe the module and browser you verified this with, e.g.: -->
Tested on Windows 10 / Chrome with an Otto <robot> and a <module name> bluetooth module: pairing, sending movement and gesture commands, and receiving sensor values.
